### PR TITLE
Add possibility to render a TypoLink using a Twig filter

### DIFF
--- a/Classes/Twig/Extension/TypoLinkExtension.php
+++ b/Classes/Twig/Extension/TypoLinkExtension.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * Twig extension for TYPO3 CMS
+ * Copyright (C) 2020 CARL von CHIARI GmbH
+ *
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 3
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Cvc\Typo3\CvcTwig\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\Service\TypoLinkCodecService;
+
+class TypoLinkExtension extends AbstractExtension
+{
+    public function getFilters()
+    {
+        return [
+            new TwigFilter('t3_typolink', [static::class, 'filterTypoLink'], ['is_safe' => ['html']]),
+        ];
+    }
+
+    /**
+     * Creates a link from fields supported by the link wizard.
+     * The :code:`linkText` will be wrapped within a link tag.
+     *
+     * @param string $linkText              the text that should be wrapped in an <a>-tag
+     * @param string $parameter             :code:`stdWrap.typolink` style parameter string.
+     * @param string $target                Specifies where to open the linked document (e.g. :code:`_blank`).
+     * @param string $class                 class added to the :code:`<a>`-tag
+     * @param string $title                 Title attribute of the :code:`<a>`-tag. It can give more information to the user in form of a tooltip.
+     * @param string $additionalParams      This is parameters that are added to the end of the URL. This must be code ready to insert after the last parameter.
+     *                                      See: `TypoLink documentation <https://docs.typo3.org/typo3cms/TyposcriptReference/Functions/Typolink.html#additionalparams>`__
+     * @param array  $additionalAttributes  additional HTML attributes that are added to the :code:`<a>`-tag
+     * @param bool   $useCacheHash          If set, the additionalParams list is exploded and calculated into a hash string appended to the URL, like "&cHash=ae83fd7s87".
+     *                                      See: `TypoLink documentation <https://docs.typo3.org/typo3cms/TyposcriptReference/Functions/Typolink.html#usecachehash>`__
+     * @param bool   $addQueryString        Adds the query string to start of the link.
+     *                                      See: `TypoLink documentation <https://docs.typo3.org/typo3cms/TyposcriptReference/Functions/Typolink.html#addquerystring>`__
+     * @param string $addQueryStringMethod  If set to GET or POST, then the parsed query arguments (GET or POST data) will be used.
+     *                                      See: `TypoLink documentation <https://docs.typo3.org/typo3cms/TyposcriptReference/Functions/Typolink.html#addquerystring>`__
+     * @param string $addQueryStringExclude List of query arguments to exclude from the link. Typical examples are :code:`L` or :code:`cHash`.
+     *                                      See: `TypoLink documentation <https://docs.typo3.org/typo3cms/TyposcriptReference/Functions/Typolink.html#addquerystring>`__
+     * @param bool   $absolute              Forces links to internal pages to be absolute, thus having a proper URL scheme and domain prepended.
+     *                                      See: `TypoLink documentation <https://docs.typo3.org/typo3cms/TyposcriptReference/Functions/Typolink.html#forceabsoluteurl>`__
+     *
+     * @example
+     *  {# Create links from simple text. #}
+     *  {{ 'read_more' | t3_trans | t3_typolink('t3://record?identifier=123') }}
+     * @example
+     *  {# Create links around complex HTML structures. #}
+     *  {% filter t3_typolink('t3://record?identifier=123', target='_blank') %}
+     *     <img src="read_more.png alt="read more"/>
+     *  {% endfilter %}
+     */
+    public static function filterTypoLink(
+        string $linkText,
+        string $parameter,
+        string $target = '',
+        string $class = '',
+        string $title = '',
+        string $additionalParams = '',
+        array $additionalAttributes = [],
+        bool $useCacheHash = false,
+        bool $addQueryString = false,
+        string $addQueryStringMethod = 'GET',
+        string $addQueryStringExclude = '',
+        bool $absolute = false
+    ): string {
+        // Merge the $parameter with other arguments
+        $typoLinkParameter = self::createTypoLinkParameterArrayFromArguments(
+            $parameter,
+            $target,
+            $class,
+            $title,
+            $additionalParams
+        );
+
+        // array(param1 -> value1, param2 -> value2) --> param1="value1" param2="value2" for typolink.ATagParams
+        $extraAttributes = [];
+        foreach ($additionalAttributes as $attributeName => $attributeValue) {
+            $extraAttributes[] = $attributeName.'="'.htmlspecialchars($attributeValue).'"';
+        }
+        $aTagParams = implode(' ', $extraAttributes);
+
+        /** @var ContentObjectRenderer $contentObject */
+        $contentObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $contentObject->start([], '');
+
+        return $contentObject->stdWrap(
+            $linkText,
+            [
+                'typolink.' => [
+                    'parameter' => $typoLinkParameter,
+                    'ATagParams' => $aTagParams,
+                    'useCacheHash' => $useCacheHash,
+                    'addQueryString' => $addQueryString,
+                    'addQueryString.' => [
+                        'method' => $addQueryStringMethod,
+                        'exclude' => $addQueryStringExclude,
+                    ],
+                    'forceAbsoluteUrl' => $absolute,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Transforms filter arguments to typo3link.parameters.typoscript option as array.
+     *
+     * @param string $parameter Example: 19 _blank - "testtitle \"with whitespace\"" &X=y
+     *
+     * @return string The final TypoLink string
+     */
+    private static function createTypoLinkParameterArrayFromArguments(
+        string $parameter,
+        string $target = '',
+        string $class = '',
+        string $title = '',
+        string $additionalParams = ''): string
+    {
+        $typoLinkCodec = GeneralUtility::makeInstance(TypoLinkCodecService::class);
+        $typoLinkConfiguration = $typoLinkCodec->decode($parameter);
+        if (empty($typoLinkConfiguration)) {
+            return '';
+        }
+
+        // Override target if given in target argument
+        if ($target) {
+            $typoLinkConfiguration['target'] = $target;
+        }
+
+        // Combine classes if given in both "parameter" string and "class" argument
+        if ($class) {
+            $classes = explode(' ', trim($typoLinkConfiguration['class']).' '.trim($class));
+            $typoLinkConfiguration['class'] = implode(' ', array_unique(array_filter($classes)));
+        }
+
+        // Override title if given in title argument
+        if ($title) {
+            $typoLinkConfiguration['title'] = $title;
+        }
+
+        // Combine additionalParams
+        if ($additionalParams) {
+            $typoLinkConfiguration['additionalParams'] .= $additionalParams;
+        }
+
+        return $typoLinkCodec->encode($typoLinkConfiguration);
+    }
+}

--- a/Documentation/Chapters/Twig-Filters/Index.rst
+++ b/Documentation/Chapters/Twig-Filters/Index.rst
@@ -11,11 +11,12 @@ t3_html
 =======
 
 .. code-block:: twig
+
    {{ html | t3_html(parseFuncTSPath = 'lib.parseFunc_RTE') }}
 
 
-Parses HTML that was created with an rich text editor.
 
+Parses HTML that was created with an rich text editor.
 
 Arguments
 ---------
@@ -37,11 +38,12 @@ t3_trans
 ========
 
 .. code-block:: twig
+
    {{ key | t3_trans(arguments = [], extensionName = null) }}
 
 
-Translates the given translation key into the active language.
 
+Translates the given translation key into the active language.
 
 Arguments
 ---------
@@ -64,3 +66,124 @@ extensionName
    :sep:`|` :aspect:`Default:` :code:`null`
 
    the name of the TYPO3 extension where the translation file is located
+
+t3_typolink
+===========
+
+.. code-block:: twig
+
+   {{ linkText | t3_typolink(
+       parameter,
+       target = '',
+       class = '',
+       title = '',
+       additionalParams = '',
+       additionalAttributes = [],
+       useCacheHash = false,
+       addQueryString = false,
+       addQueryStringMethod = 'GET',
+       addQueryStringExclude = '',
+       absolute = false
+   ) }}
+
+
+
+Creates a link from fields supported by the link wizard.
+
+The :code:`linkText` will be wrapped within a link tag.
+
+.. code-block:: twig
+
+   {# Create links from simple text. #}
+   {{ 'read_more' | t3_trans | t3_typolink('t3://record?identifier=123') }}
+
+
+.. code-block:: twig
+
+   {# Create links around complex HTML structures. #}
+   {% filter t3_typolink('t3://record?identifier=123', target='_blank') %}
+      <img src="read_more.png alt="read more"/>
+   {% endfilter %}
+
+
+
+Arguments
+---------
+
+.. rst-class:: dl-parameters
+
+linkText
+   :aspect:`Type:` :code:`string`
+
+   the text that should be wrapped in an <a>-tag
+
+parameter
+   :aspect:`Type:` :code:`string`
+
+   :code:`stdWrap.typolink` style parameter string.
+
+target
+   :aspect:`Type:` :code:`string`
+   :sep:`|` :aspect:`Default:` :code:`''`
+
+   Specifies where to open the linked document (e.g. :code:`_blank`).
+
+class
+   :aspect:`Type:` :code:`string`
+   :sep:`|` :aspect:`Default:` :code:`''`
+
+   class added to the :code:`<a>`-tag
+
+title
+   :aspect:`Type:` :code:`string`
+   :sep:`|` :aspect:`Default:` :code:`''`
+
+   Title attribute of the :code:`<a>`-tag. It can give more information to the user in form of a tooltip.
+
+additionalParams
+   :aspect:`Type:` :code:`string`
+   :sep:`|` :aspect:`Default:` :code:`''`
+
+   This is parameters that are added to the end of the URL. This must be code ready to insert after the last parameter.
+   See: `TypoLink documentation <https://docs.typo3.org/typo3cms/TyposcriptReference/Functions/Typolink.html#additionalparams>`__
+
+additionalAttributes
+   :aspect:`Type:` :code:`array`
+   :sep:`|` :aspect:`Default:` :code:`[]`
+
+   additional HTML attributes that are added to the :code:`<a>`-tag
+
+useCacheHash
+   :aspect:`Type:` :code:`bool`
+   :sep:`|` :aspect:`Default:` :code:`false`
+
+   If set, the additionalParams list is exploded and calculated into a hash string appended to the URL, like "&cHash=ae83fd7s87".
+   See: `TypoLink documentation <https://docs.typo3.org/typo3cms/TyposcriptReference/Functions/Typolink.html#usecachehash>`__
+
+addQueryString
+   :aspect:`Type:` :code:`bool`
+   :sep:`|` :aspect:`Default:` :code:`false`
+
+   Adds the query string to start of the link.
+   See: `TypoLink documentation <https://docs.typo3.org/typo3cms/TyposcriptReference/Functions/Typolink.html#addquerystring>`__
+
+addQueryStringMethod
+   :aspect:`Type:` :code:`string`
+   :sep:`|` :aspect:`Default:` :code:`'GET'`
+
+   If set to GET or POST, then the parsed query arguments (GET or POST data) will be used.
+   See: `TypoLink documentation <https://docs.typo3.org/typo3cms/TyposcriptReference/Functions/Typolink.html#addquerystring>`__
+
+addQueryStringExclude
+   :aspect:`Type:` :code:`string`
+   :sep:`|` :aspect:`Default:` :code:`''`
+
+   List of query arguments to exclude from the link. Typical examples are :code:`L` or :code:`cHash`.
+   See: `TypoLink documentation <https://docs.typo3.org/typo3cms/TyposcriptReference/Functions/Typolink.html#addquerystring>`__
+
+absolute
+   :aspect:`Type:` :code:`bool`
+   :sep:`|` :aspect:`Default:` :code:`false`
+
+   Forces links to internal pages to be absolute, thus having a proper URL scheme and domain prepended.
+   See: `TypoLink documentation <https://docs.typo3.org/typo3cms/TyposcriptReference/Functions/Typolink.html#forceabsoluteurl>`__

--- a/Documentation/Chapters/Twig-Functions/Index.rst
+++ b/Documentation/Chapters/Twig-Functions/Index.rst
@@ -11,7 +11,9 @@ dump
 ====
 
 .. code-block:: twig
+
    {{ dump(vars) }}
+
 
 
 Displays the content of the variable(s) on the screen.
@@ -22,6 +24,7 @@ Please ensure that the frontend debug mode is on, because otherwise the function
 Internally :code:`DebuggerUtility::var_dump()` is used.
 
 .. code-block:: twig
+
    {# print a single variable #}
    {{ dump(foo) }}
    
@@ -30,6 +33,8 @@ Internally :code:`DebuggerUtility::var_dump()` is used.
    
    {# print all variables #}
    {{ dump() }}
+
+
 
 Arguments
 ---------
@@ -45,6 +50,7 @@ t3_cobject
 ==========
 
 .. code-block:: twig
+
    {{ t3_cobject(
        typoScriptObjectPath,
        data = null,
@@ -53,8 +59,8 @@ t3_cobject
    ) }}
 
 
-Renders a TypoScript object. The content object renderer can be populated using the data argument.
 
+Renders a TypoScript object. The content object renderer can be populated using the data argument.
 
 Arguments
 ---------
@@ -80,6 +86,7 @@ t3_uri_action
 =============
 
 .. code-block:: twig
+
    {{ t3_uri_action(
        action,
        arguments = [],
@@ -173,6 +180,7 @@ t3_uri_image
 ============
 
 .. code-block:: twig
+
    {{ t3_uri_image(
        src = null,
        treatIdAsReference = false,
@@ -189,8 +197,8 @@ t3_uri_image
    ) }}
 
 
-Returns the URL to the given image. If an error occurs, then :code:`null` is returned and no error is raised.
 
+Returns the URL to the given image. If an error occurs, then :code:`null` is returned and no error is raised.
 
 Arguments
 ---------
@@ -253,12 +261,14 @@ t3_uri_model
 ============
 
 .. code-block:: twig
+
    {{ t3_uri_model(model) }}
+
 
 
 Generates a link fro the given domain model.
 
-A `link handler &lt;https://docs.typo3.org/typo3cms/extensions/core/latest/Changelog/8.6/Feature-79626-IntegrateRecordLinkHandler.html&gt;`__ must be configured for the mapped table.
+A `link handler <https://docs.typo3.org/typo3cms/extensions/core/latest/Changelog/8.6/Feature-79626-IntegrateRecordLinkHandler.html>`__ must be configured for the mapped table.
 
 
 Arguments
@@ -273,6 +283,7 @@ t3_uri_page
 ===========
 
 .. code-block:: twig
+
    {{ t3_uri_page(
        pageUid = null,
        additionalParams = [],
@@ -337,12 +348,14 @@ t3_uri_record
 =============
 
 .. code-block:: twig
+
    {{ t3_uri_record(table, recordUid) }}
+
 
 
 Generates a link for the given record.
 
-A `link handler &lt;https://docs.typo3.org/typo3cms/extensions/core/latest/Changelog/8.6/Feature-79626-IntegrateRecordLinkHandler.html&gt;`__ must be configured for the mapped table.
+A `link handler <https://docs.typo3.org/typo3cms/extensions/core/latest/Changelog/8.6/Feature-79626-IntegrateRecordLinkHandler.html>`__ must be configured for the mapped table.
 
 
 Arguments
@@ -364,6 +377,7 @@ t3_uri_typolink
 ===============
 
 .. code-block:: twig
+
    {{ t3_uri_typolink(parameter, additionalParams = []) }}
 
 

--- a/Resources/Private/TwigTemplates/Documentation/filtersAndFunctions.rst.twig
+++ b/Resources/Private/TwigTemplates/Documentation/filtersAndFunctions.rst.twig
@@ -15,41 +15,42 @@
 
 
 .. code-block:: twig
-{% for line in description.defaultExample|split("\n") %}
-   {{ line | raw }}
-{% endfor %}
+
+   {{ description.defaultExample | replace({"\n": "\n   "}) | raw }}
+
 
 {% if description.summary %}
 
-{{ description.summary }}
+{{ description.summary | raw }}
 {% endif %}
 {% if description.hasDescriptionText %}
 
-{{ description.descriptionText }}
-{% endif %}
+{{ description.descriptionText | raw }}
 
+{% endif %}
 {% for example in description.examples %}
 .. code-block:: twig
-{% for line in example.sourceCode|split("\n") %}
-   {{ line | raw }}
-{% endfor %}
-{% endfor %}
-{% if description.parameters %}
 
+   {{ example.sourceCode | replace({"\n": "\n   "}) | raw }}
+
+
+{% endfor %}
+
+{% if description.parameters %}
 Arguments
 ---------
 
 .. rst-class:: dl-parameters
 {% for parameter in description.parameters %}
 
-{{ parameter.name }}
+{{ parameter.name | raw }}
    :aspect:`Type:` :code:`{{ parameter.type | default('mixed') }}`
 {% if parameter.hasDefaultValue %}
    :sep:`|` :aspect:`Default:` :code:`{{ parameter.defaultValue | raw }}`
 {% endif %}
 {% if parameter.summary %}
 
-   {{ parameter.summary }}
+   {{ parameter.summary | replace({"\n": "\n   "}) | raw }}
 {% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
The filter will surround the inner content with an <a>-tag according to the link parameter.