### PR TITLE
Add settings option in TypoScript

### DIFF
--- a/Classes/ContentObject/TwigTemplateContentObject.php
+++ b/Classes/ContentObject/TwigTemplateContentObject.php
@@ -22,6 +22,7 @@ use Cvc\Typo3\CvcTwig\Mvc\View\StandaloneViewFactory;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
+use TYPO3\CMS\Core\TypoScript\TypoScriptService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\StringUtility;
 use TYPO3\CMS\Frontend\ContentObject\AbstractContentObject;
@@ -35,13 +36,13 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
  *
  * page.10 = TWIGTEMPLATE
  * page.10 {
- *     template = example.html.twig
+ *     templateName = example.html.twig
  *     variables {
  *         foo = TEXT
  *         foo.value = Bar!
  *     }
  *     templateRootPaths {
- *         10 = EXT:twig/Resources/Private/TwigTemplates
+ *         10 = EXT:twig/Resources/Private/TwigTemplates/
  *     }
  * }
  *
@@ -51,6 +52,7 @@ class TwigTemplateContentObject extends AbstractContentObject
 {
     private ContentDataProcessor $contentDataProcessor;
     private StandaloneViewFactory $standaloneViewFactory;
+    private TypoScriptService $typoScriptService;
 
     public function __construct(ContentObjectRenderer $cObj)
     {
@@ -60,9 +62,12 @@ class TwigTemplateContentObject extends AbstractContentObject
         assert($contentDataProcessor instanceof ContentDataProcessor);
         $standaloneViewFactory = GeneralUtility::getContainer()->get(StandaloneViewFactory::class);
         assert($standaloneViewFactory instanceof StandaloneViewFactory);
+        $typoScriptService = GeneralUtility::makeInstance(TypoScriptService::class);
+        assert($typoScriptService instanceof TypoScriptService);
 
         $this->contentDataProcessor = $contentDataProcessor;
         $this->standaloneViewFactory = $standaloneViewFactory;
+        $this->typoScriptService = $typoScriptService;
     }
 
     /**
@@ -191,17 +196,11 @@ class TwigTemplateContentObject extends AbstractContentObject
      * Returns any TypoScript settings.
      *
      * @param array $conf Configuration
-     *
-     * @return array|null
      */
     private function getSettings(array $conf): ?array
     {
         if (isset($conf['settings.'])) {
-            /** @var TypoScriptService $typoScriptService */
-            $typoScriptService = GeneralUtility::makeInstance(TypoScriptService::class);
-            $settings = $typoScriptService->convertTypoScriptArrayToPlainArray($conf['settings.']);
-
-            return $settings;
+            return $this->typoScriptService->convertTypoScriptArrayToPlainArray($conf['settings.']);
         }
 
         return null;

--- a/Classes/ContentObject/TwigTemplateContentObject.php
+++ b/Classes/ContentObject/TwigTemplateContentObject.php
@@ -121,6 +121,10 @@ class TwigTemplateContentObject extends AbstractContentObject
         $variables = $this->contentDataProcessor->process($this->cObj, $conf, $variables);
 
         $view = $this->standaloneViewFactory->create();
+        $settings = $this->getSettings($conf);
+        if ($settings) {
+            $view->assign('settings', $settings);
+        }
         $view->setTemplateName($templateName);
         $view->setTemplateRootPaths($templateRootPaths);
         $view->setNamespaces($namespaces);
@@ -181,5 +185,25 @@ class TwigTemplateContentObject extends AbstractContentObject
         $variables['current'] = $this->cObj->data[$this->cObj->currentValKey];
 
         return $variables;
+    }
+
+    /**
+     * Returns any TypoScript settings.
+     *
+     * @param array $conf Configuration
+     *
+     * @return array|null
+     */
+    private function getSettings(array $conf): ?array
+    {
+        if (isset($conf['settings.'])) {
+            /** @var TypoScriptService $typoScriptService */
+            $typoScriptService = GeneralUtility::makeInstance(TypoScriptService::class);
+            $settings = $typoScriptService->convertTypoScriptArrayToPlainArray($conf['settings.']);
+
+            return $settings;
+        }
+
+        return null;
     }
 }

--- a/Classes/Twig/Test/FunctionalTestCase.php
+++ b/Classes/Twig/Test/FunctionalTestCase.php
@@ -18,12 +18,12 @@
 
 namespace Cvc\Typo3\CvcTwig\Twig\Test;
 
+use Nimut\TestingFramework\TestCase\FunctionalTestCase as Typo3FunctionalTestCase;
 use Twig\Environment;
 use Twig\Error\Error;
 use Twig\Extension\ExtensionInterface;
 use Twig\Loader\ArrayLoader;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase as Typo3FunctionalTestCase;
 
 /**
  * Inspired by twig/twig package src/Test/IntegrationTestCase.php and adjusted to TYPO3.

--- a/Documentation/Chapters/Getting-Started/Index.rst
+++ b/Documentation/Chapters/Getting-Started/Index.rst
@@ -24,7 +24,7 @@ To render a Twig template you can use the :code:`TWIGTEMPLATE` content object.
             foo.value = Bar!
         }
         templateRootPaths {
-            10 = EXT:twig/Resources/Private/TwigTemplates
+            10 = EXT:twig/Resources/Private/TwigTemplates/
         }
     }
 

--- a/Tests/Functional/ContentObject/RenderTwigTemplateTest.php
+++ b/Tests/Functional/ContentObject/RenderTwigTemplateTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Twig extension for TYPO3 CMS
+ * Copyright (C) 2020 CARL von CHIARI GmbH
+ *
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 3
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Cvc\Typo3\CvcTwig\Tests\Functional\ContentObject;
+
+use Nimut\TestingFramework\TestCase\FunctionalTestCase;
+
+class RenderTwigTemplateTest extends FunctionalTestCase
+{
+    protected $testExtensionsToLoad = [
+        'typo3conf/ext/cvc_twig',
+        'typo3conf/ext/cvc_twig/Tests/Functional/Fixtures/Extensions/twig_test',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importDataSet(__DIR__.'/../../../.Build/vendor/nimut/testing-framework/res/Fixtures/Database/pages.xml');
+        $this->setUpFrontendRootPage(1, [__DIR__.'/../Fixtures/Extensions/twig_test/Configuration/TypoScript/page.typoscript']);
+    }
+
+    public function test_template_is_rendered(): void
+    {
+        $this->assertContains("Foo Bar! Settings: Ipsum.\n", $this->getFrontendResponse(1)->getContent());
+    }
+}

--- a/Tests/Functional/Fixtures/Extensions/twig_test/Configuration/TypoScript/page.typoscript
+++ b/Tests/Functional/Fixtures/Extensions/twig_test/Configuration/TypoScript/page.typoscript
@@ -1,0 +1,12 @@
+page = PAGE
+page.10 = TWIGTEMPLATE
+page.10 {
+    templateName = EXT:twig_test/Resources/Private/TwigTemplates/example.html.twig
+    variables {
+        foo = TEXT
+        foo.value = Bar!
+    }
+    settings {
+        lorem = Ipsum
+    }
+}

--- a/Tests/Functional/Fixtures/Extensions/twig_test/Resources/Private/TwigTemplates/example.html.twig
+++ b/Tests/Functional/Fixtures/Extensions/twig_test/Resources/Private/TwigTemplates/example.html.twig
@@ -1,0 +1,1 @@
+Foo {{ foo }} Settings: {{ settings.lorem }}.

--- a/Tests/Functional/Fixtures/Extensions/twig_test/ext_emconf.php
+++ b/Tests/Functional/Fixtures/Extensions/twig_test/ext_emconf.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Twig extension for TYPO3 CMS
+ * Copyright (C) 2020 CARL von CHIARI GmbH
+ *
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 3
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'Twig Test Extension',
+    'description' => '',
+    'category' => 'fe',
+    'author' => 'CARL von CHIARI',
+    'author_email' => 'opensource@cvc.digital',
+    'author_company' => 'CARL von CHIARI GmbH',
+    'state' => 'stable',
+    'version' => '1.0.0',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '',
+            'cvc_twig' => '',
+        ],
+    ],
+];

--- a/Tests/Functional/Mvc/View/StandaloneViewTest.php
+++ b/Tests/Functional/Mvc/View/StandaloneViewTest.php
@@ -19,8 +19,8 @@
 namespace Cvc\Typo3\CvcTwig\Tests\Functional\Mvc\View;
 
 use Cvc\Typo3\CvcTwig\Mvc\View\StandaloneViewFactory;
+use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 class StandaloneViewTest extends FunctionalTestCase
 {

--- a/composer.json
+++ b/composer.json
@@ -32,11 +32,11 @@
         "cvc/twig-documentor": "^0.3",
         "ergebnis/composer-normalize": "^2.3",
         "friendsofphp/php-cs-fixer": "^2.16",
+        "nimut/testing-framework": "^5.1",
         "phpstan/phpstan": "^0.12.18",
-        "phpunit/phpunit": "^9",
+        "phpunit/phpunit": "^7",
         "symfony/var-dumper": "^4.3",
-        "typo3/cms-form": "^10.4",
-        "typo3/testing-framework": "^6"
+        "typo3/cms-form": "^10.4"
     },
     "config": {
         "bin-dir": ".Build/bin",
@@ -64,7 +64,7 @@
     },
     "scripts": {
         "post-autoload-dump": [
-            "TYPO3\\TestingFramework\\Composer\\ExtensionTestEnvironment::prepare"
+            "Nimut\\TestingFramework\\Composer\\ExtensionTestEnvironment::prepare"
         ]
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <phpunit
     backupGlobals="true"
-    bootstrap=".Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
+    bootstrap=".Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTestsBootstrap.php"
     colors="true"
     convertErrorsToExceptions="true"
     convertWarningsToExceptions="true"


### PR DESCRIPTION
Within TypoScript the settings array can be used to add additional configuration options.
These options are stored in a view variable called "settings".