### PR TITLE
Add support for namespaced template paths

### DIFF
--- a/Classes/ContentObject/TwigTemplateContentObject.php
+++ b/Classes/ContentObject/TwigTemplateContentObject.php
@@ -78,6 +78,11 @@ class TwigTemplateContentObject extends AbstractContentObject
      *     templateRootPaths {
      *         10 = EXT:twig/Resources/Private/TwigTemplates
      *     }
+     *     namespaces {
+     *         components {
+     *             10 = EXT:example_site/Private/frontend/src/components
+     *         }
+     *     }
      * }
      *
      * @param array $conf Array of TypoScript properties
@@ -96,12 +101,20 @@ class TwigTemplateContentObject extends AbstractContentObject
             ? $this->applyStandardWrapToTwigPaths($conf['templateRootPaths.'])
             : [];
 
+        $namespaces = [];
+        if (isset($conf['namespaces.'])) {
+            foreach ($conf['namespaces.'] as $namespace => $paths) {
+                $namespaces[rtrim($namespace, '.')] = $paths;
+            }
+        }
+
         $variables = $this->getContentObjectVariables($conf);
         $variables = $this->contentDataProcessor->process($this->cObj, $conf, $variables);
 
         $view = GeneralUtility::makeInstance(StandaloneView::class);
         $view->setTemplateName($templateName);
         $view->setTemplateRootPaths($templateRootPaths);
+        $view->setNamespaces($namespaces);
         $view->assignMultiple($variables);
 
         return $view->render();

--- a/Documentation/Chapters/ContentObject/Index.rst
+++ b/Documentation/Chapters/ContentObject/Index.rst
@@ -57,3 +57,27 @@ dataProcessing
         }
 
     The build-in data processors are documented `here <https://docs.typo3.org/typo3cms/TyposcriptReference/ContentObjects/Fluidtemplate/Index.html#dataprocessing>`__.
+
+namespaces
+    :aspect:`Type` :code:`array`
+
+    The file loader shipped with Twig allows to register namespaced folders.
+    A namespace can be referenced with :code:`@namespace` followed by the path to the template.
+
+    **Example:**
+
+    .. code-block:: typoscript
+
+        page.10 = TWIGTEMPLATE
+        page.10 {
+            templateName = @myComponents/text_and_media.html.twig
+            namespaces {
+                myComponents {
+                    10 = EXT:example_site/Private/frontend/src/components
+                }
+            }
+        }
+
+    The given code example defines a namespace called :code:`myComponents`.
+    A template that is located in :code:`EXT:example_site/Private/frontend/src/components` can be referenced using the namespace.
+    The template name will looks like :code:`@myComponents/text_and_media.html.twig`.


### PR DESCRIPTION
See documentation: https://twig.symfony.com/doc/2.x/api.html#built-in-loaders

The namespaced templates can be used as follows:

```typoscript
10 = TWIGTEMPLATE
10 {
    templateName = @components/text_and_media.html.twig
    namespaces {
        components {
            10 = EXT:example_site/Private/frontend/src/components
        }
    }
}
```

The namespaced templates can be then referenced with `@components` where `@` indicates that a namespace should be used and `components` is the name of the namespace.

In the given example the following template will be resolved: `EXT:example_site/Private/frontend/src/components/text_and_media.html.twig`.

**Todo:**
- [x] write code
- [x] write documentation


FYI @marclindemann @robinkitzelmann 