### PR TITLE
Fix link generating Twig functions

### DIFF
--- a/Classes/Mvc/View/StandaloneView.php
+++ b/Classes/Mvc/View/StandaloneView.php
@@ -31,10 +31,12 @@ use Cvc\Typo3\CvcTwig\Twig\Loader\Typo3Loader;
 use Twig\Loader\ChainLoader;
 use Twig\Loader\FilesystemLoader;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ControllerContext;
 use TYPO3\CMS\Extbase\Mvc\Web\Request;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 /**
  * A standalone view.
@@ -207,6 +209,10 @@ class StandaloneView
         }
 
         $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+
+        $configurationManager = $objectManager->get(ConfigurationManagerInterface::class);
+        $contentObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $configurationManager->setContentObject($contentObject);
 
         $request = $objectManager->get(Request::class);
         $request->setRequestUri(GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL'));


### PR DESCRIPTION
The content object needs to be added to the configuration manager.
Otherwise an exception is thrown.

Fixes #11