### PR TITLE
Fix TYPO3 Extension Repository ZIP-file

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -16,10 +16,6 @@
  * The TYPO3 project - inspiring people to share!
  */
 
-if (!isset($_EXTKEY)) {
-    $_EXTKEY = '';
-}
-
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Twig Template Engine',
     'description' => 'Use the Twig template engine within your TYPO3 project. You can use Twig templates in TypoScript or together with Extbase.',

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -17,3 +17,4 @@
  */
 
 define('TYPO3_MODE', 'FE');
+$_EXTKEY = 'cvc_twig';


### PR DESCRIPTION
No additional PHP code may be present in ext_emconf.php, otherwise the ZIP-upload will fail.