### PR TITLE
templateRootPaths incorrect

### DIFF
--- a/Documentation/Chapters/Getting-Started/Index.rst
+++ b/Documentation/Chapters/Getting-Started/Index.rst
@@ -24,7 +24,7 @@ To render a Twig template you can use the :code:`TWIGTEMPLATE` content object.
             foo.value = Bar!
         }
         templateRootPaths {
-            10 = EXT:twig/Resources/Private/TwigTemplates/
+            10 = EXT:cvc_twig/Resources/Private/TwigTemplates/
         }
     }
 


### PR DESCRIPTION
10 = EXT:twig/Resources/Private/TwigTemplates/
should be 
10 = EXT:cvc_twig/Resources/Private/TwigTemplates/
or you will get an error.

The manual on Github itself is corrected, the Typo3 manual is not.