### PR TITLE
With these adjustments, the EXT runs with TYPO3 11.5 LTS for the time being

### DIFF
--- a/Classes/Extbase/Mvc/ControllerContextStack.php
+++ b/Classes/Extbase/Mvc/ControllerContextStack.php
@@ -65,9 +65,8 @@ final class ControllerContextStack
             $contentObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
             $configurationManager->setContentObject($contentObject);
 
+            /** @var $request Request::class */
             $request = $this->objectManager->get(Request::class);
-            $request->setRequestUri(GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL'));
-            $request->setBaseUri(GeneralUtility::getIndpEnv('TYPO3_SITE_URL'));
             $uriBuilder = $this->objectManager->get(UriBuilder::class);
             $uriBuilder->setRequest($request);
             $this->default = $this->objectManager->get(ControllerContext::class);

--- a/Classes/Twig/Extension/FormExtension.php
+++ b/Classes/Twig/Extension/FormExtension.php
@@ -23,8 +23,7 @@ use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Mvc\Web\Request;
-use TYPO3\CMS\Extbase\Mvc\Web\Response;
+use TYPO3\CMS\Extbase\Mvc\Request;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Form\Domain\Factory\ArrayFormFactory;
 use TYPO3\CMS\Form\Domain\Factory\FormFactoryInterface;
@@ -87,24 +86,9 @@ class FormExtension extends AbstractExtension
         /** @var FormFactoryInterface $factory */
         $factory = $this->objectManager->get($factoryClass);
         $formDefinition = $factory->build($overrideConfiguration, $prototypeName);
-        $response = $controllerContext->getResponse() ?? $this->objectManager->get(Response::class);
-        assert($response instanceof Response);
         $request = $controllerContext->getRequest();
         assert($request instanceof Request);
-        $form = $formDefinition->bind($request, $response);
-
-        // If the controller context does not contain a response object, this viewhelper is used in a
-        // fluid template rendered by the FluidTemplateContentObject. Handle the StopActionException
-        // as there is no extbase dispatcher involved that catches that. */
-        /** @var Response|null $responseFromControllerContext */
-        $responseFromControllerContext = $controllerContext->getResponse();
-        if ($responseFromControllerContext === null) {
-            try {
-                return $form->render();
-            } catch (\TYPO3\CMS\Extbase\Mvc\Exception\StopActionException $exception) {
-                return $response->shutdown();
-            }
-        }
+        $form = $formDefinition->bind($request);
 
         return $form->render();
     }

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
     "require": {
         "php": "^7.4",
         "twig/twig": "^3",
-        "typo3/cms-core": "^10.4",
-        "typo3/cms-extbase": "^10.4",
-        "typo3/cms-frontend": "^10.4"
+        "typo3/cms-core": "^11.5",
+        "typo3/cms-extbase": "^11.5",
+        "typo3/cms-frontend": "^11.5"
     },
     "replace": {
         "typo3-ter/cvc_twig": "self.version"
@@ -36,7 +36,7 @@
         "phpstan/phpstan": "^0.12.18",
         "phpunit/phpunit": "^7",
         "symfony/var-dumper": "^4.3",
-        "typo3/cms-form": "^10.4"
+        "typo3/cms-form": "^11.5"
     },
     "config": {
         "bin-dir": ".Build/bin",


### PR DESCRIPTION
The adjustments basically concern the use of the request and response object, which has changed with TYPO3 11.