### PR TITLE
(update/typo3-12) Add cache "twig_templates" to cache group "pages"

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -27,5 +27,6 @@ if (!array_key_exists('twig_templates', $GLOBALS['TYPO3_CONF_VARS']['SYS']['cach
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['twig_templates'] = [
         'backend' => \TYPO3\CMS\Core\Cache\Backend\FileBackend::class,
         'frontend' => \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class,
+        'groups' => ['pages'],
     ];
 }


### PR DESCRIPTION
See:
- [TYPO3 Docs "Caches in the TYPO3 Core"](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/CachingFramework/Architecture/Index.html#caches-in-the-typo3-core)
>Cache clearing commands can be issued to target a particular group. If a cache does not belong to a group, it will be flushed when the "all" group is flushed, but such caches should normally be [transient](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/CachingFramework/FrontendsBackends/Index.html#caching-backend-transient) anyway.
- [typo3/cms-core DefaultConfiguration.php](https://github.com/TYPO3-CMS/core/blob/b5bc0fd401d4889784df7dff19bbe7a155bc442d/Configuration/DefaultConfiguration.php#L181C1-L181C1)